### PR TITLE
Modify find command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -15,7 +15,7 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names and/or courses contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names/courses contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -15,14 +15,14 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names and/or courses contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final NameOrCourseContainsKeywordsPredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(NameOrCourseContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,12 +3,10 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +36,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 .orElse(new ArrayList<>());
 
         if (nameKeywords.isEmpty() && courseKeywords.isEmpty()) {
-            throw new ParseException("At least one name or course filter must be provided.");
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
         return new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords));

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,9 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,18 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -19,15 +25,22 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_COURSE);
+
+        List<String> nameKeywords = argMultimap.getValue(PREFIX_NAME)
+                .map(value -> Arrays.asList(value.split("\\s+")))
+                .orElse(new ArrayList<>());
+
+        List<String> courseKeywords = argMultimap.getValue(PREFIX_COURSE)
+                .map(value -> Arrays.asList(value.split("\\s+")))
+                .orElse(new ArrayList<>());
+
+        if (nameKeywords.isEmpty() && courseKeywords.isEmpty()) {
+            throw new ParseException("At least one name or course filter must be provided.");
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COURSE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;

--- a/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import java.util.List;
 import java.util.function.Predicate;
+
 import seedu.address.commons.util.StringUtil;
 
 /**
@@ -11,6 +12,14 @@ public class NameOrCourseContainsKeywordsPredicate implements Predicate<Person> 
     private final List<String> nameKeywords;
     private final List<String> courseKeywords;
 
+    /**
+     * Constructs a {@code NameOrCourseContainsKeywordsPredicate} with the given keywords for name and course filtering.
+     *
+     * @param nameKeywords A list of keywords used to filter contacts by name.
+     *                     If empty, no name-based filtering is applied.
+     * @param courseKeywords A list of keywords used to filter contacts by course.
+     *                       If empty, no course-based filtering is applied.
+     */
     public NameOrCourseContainsKeywordsPredicate(List<String> nameKeywords, List<String> courseKeywords) {
         this.nameKeywords = nameKeywords;
         this.courseKeywords = courseKeywords;

--- a/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
 
 /**
  * Tests that a {@code Person}'s {@code Name} or {@code Course} matches any of the keywords given.
@@ -50,4 +51,13 @@ public class NameOrCourseContainsKeywordsPredicate implements Predicate<Person> 
         NameOrCourseContainsKeywordsPredicate otherPredicate = (NameOrCourseContainsKeywordsPredicate) other;
         return nameKeywords.equals(otherPredicate.nameKeywords) && courseKeywords.equals(otherPredicate.courseKeywords);
     }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("nameKeywords", nameKeywords)
+                .add("courseKeywords", courseKeywords)
+                .toString();
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} or {@code Course} matches any of the keywords given.
+ */
+public class NameOrCourseContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> nameKeywords;
+    private final List<String> courseKeywords;
+
+    public NameOrCourseContainsKeywordsPredicate(List<String> nameKeywords, List<String> courseKeywords) {
+        this.nameKeywords = nameKeywords;
+        this.courseKeywords = courseKeywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        boolean matchesName = nameKeywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+
+        boolean matchesCourse = courseKeywords.stream()
+                .anyMatch(keyword -> person.getCourses().stream()
+                        .anyMatch(course -> StringUtil.containsWordIgnoreCase(course.toString(), keyword)));
+
+        return matchesName || matchesCourse;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof NameOrCourseContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        NameOrCourseContainsKeywordsPredicate otherPredicate = (NameOrCourseContainsKeywordsPredicate) other;
+        return nameKeywords.equals(otherPredicate.nameKeywords) && courseKeywords.equals(otherPredicate.courseKeywords);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate ;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -29,10 +29,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        NameOrCourseContainsKeywordsPredicate firstPredicate =
+                new NameOrCourseContainsKeywordsPredicate(Collections.singletonList("first"), Collections.emptyList());
+        NameOrCourseContainsKeywordsPredicate  secondPredicate =
+                new NameOrCourseContainsKeywordsPredicate(Collections.singletonList("second"), Collections.emptyList());
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -57,7 +57,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate(" ", "");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +67,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz", "");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -75,8 +75,29 @@ public class FindCommandTest {
     }
 
     @Test
+    public void execute_courseKeyword_personsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate("", "CS2101");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        // Assuming there are persons enrolled in CS2101, update accordingly
+    }
+
+    @Test
+    public void execute_nameAndCourseKeywords_personsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate("Frank", "CS2101");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        // Assuming persons named Frank enrolled in CS2101, update accordingly
+    }
+
+    @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        NameOrCourseContainsKeywordsPredicate predicate = new
+                NameOrCourseContainsKeywordsPredicate(Arrays.asList("keyword"), Arrays.asList("CS2101"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
@@ -85,7 +106,9 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private NameOrCourseContainsKeywordsPredicate preparePredicate(String userInput, String userInputCourse) {
+        return new NameOrCourseContainsKeywordsPredicate(
+                Arrays.asList(userInput.split("\\s+")),
+                Arrays.asList(userInputCourse.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate ;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -31,7 +31,7 @@ public class FindCommandTest {
     public void equals() {
         NameOrCourseContainsKeywordsPredicate firstPredicate =
                 new NameOrCourseContainsKeywordsPredicate(Collections.singletonList("first"), Collections.emptyList());
-        NameOrCourseContainsKeywordsPredicate  secondPredicate =
+        NameOrCourseContainsKeywordsPredicate secondPredicate =
                 new NameOrCourseContainsKeywordsPredicate(Collections.singletonList("second"), Collections.emptyList());
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -75,26 +75,6 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_courseKeyword_personsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate("", "CS2101");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        // Assuming there are persons enrolled in CS2101, update accordingly
-    }
-
-    @Test
-    public void execute_nameAndCourseKeywords_personsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
-        NameOrCourseContainsKeywordsPredicate predicate = preparePredicate("Frank", "CS2101");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        // Assuming persons named Frank enrolled in CS2101, update accordingly
-    }
-
-    @Test
     public void toStringMethod() {
         NameOrCourseContainsKeywordsPredicate predicate = new
                 NameOrCourseContainsKeywordsPredicate(Arrays.asList("keyword"), Arrays.asList("CS2101"));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -76,20 +76,21 @@ public class AddressBookParserTest {
 
         // Only name keywords
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " n/" + nameKeywords.stream().collect(
+                        Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords,
                 Collections.emptyList())), command);
 
         // Only course keywords
         FindCommand commandWithCourse = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " c/CS2101 c/CS2103");
+                FindCommand.COMMAND_WORD + " c/CS2101 CS2103");
         assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(
                 Collections.emptyList(), courseKeywords)), commandWithCourse);
 
         // Both name and course keywords
         FindCommand commandWithBoth = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(
-                        Collectors.joining(" ")) + " c/CS2101 c/CS2103");
+                FindCommand.COMMAND_WORD + " n/ " + nameKeywords.stream().collect(
+                        Collectors.joining(" ")) + " c/CS2101 CS2103");
         assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords)),
                 commandWithBoth);
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -77,17 +77,21 @@ public class AddressBookParserTest {
         // Only name keywords
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, Collections.emptyList())), command);
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords,
+                Collections.emptyList())), command);
 
         // Only course keywords
         FindCommand commandWithCourse = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " c/CS2101 c/CS2103");
-        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), courseKeywords)), commandWithCourse);
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(
+                Collections.emptyList(), courseKeywords)), commandWithCourse);
 
         // Both name and course keywords
         FindCommand commandWithBoth = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(Collectors.joining(" ")) + " c/CS2101 c/CS2103");
-        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords)), commandWithBoth);
+                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(
+                        Collectors.joining(" ")) + " c/CS2101 c/CS2103");
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords)),
+                commandWithBoth);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,7 +24,7 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -70,10 +71,23 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        List<String> nameKeywords = Arrays.asList("foo", "bar");
+        List<String> courseKeywords = Arrays.asList("CS2101", "CS2103");
+
+        // Only name keywords
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, Collections.emptyList())), command);
+
+        // Only course keywords
+        FindCommand commandWithCourse = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " c/CS2101 c/CS2103");
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), courseKeywords)), commandWithCourse);
+
+        // Both name and course keywords
+        FindCommand commandWithBoth = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_WORD + " " + nameKeywords.stream().collect(Collectors.joining(" ")) + " c/CS2101 c/CS2103");
+        assertEquals(new FindCommand(new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords)), commandWithBoth);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -5,11 +5,12 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailur
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.NameOrCourseContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -24,11 +25,24 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"),
+                        Collections.emptyList()));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+
+        // course keywords only
+        FindCommand expectedFindCommandWithCourse =
+                new FindCommand(new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(),
+                        Arrays.asList("CS2101", "CS2103")));
+        assertParseSuccess(parser, "c/CS2101 c/CS2103", expectedFindCommandWithCourse);
+
+        // both name and course keywords
+        FindCommand expectedFindCommandWithNameAndCourse =
+                new FindCommand(new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"),
+                        Arrays.asList("CS2101")));
+        assertParseSuccess(parser, "Alice Bob c/CS2101", expectedFindCommandWithNameAndCourse);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -18,7 +18,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -27,22 +28,22 @@ public class FindCommandParserTest {
         FindCommand expectedFindCommand =
                 new FindCommand(new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"),
                         Collections.emptyList()));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+        assertParseSuccess(parser, "find n/Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        assertParseSuccess(parser, "find n/Alice   Bob", expectedFindCommand);
 
         // course keywords only
         FindCommand expectedFindCommandWithCourse =
                 new FindCommand(new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(),
                         Arrays.asList("CS2101", "CS2103")));
-        assertParseSuccess(parser, "c/CS2101 c/CS2103", expectedFindCommandWithCourse);
+        assertParseSuccess(parser, "find c/CS2101 CS2103", expectedFindCommandWithCourse);
 
         // both name and course keywords
         FindCommand expectedFindCommandWithNameAndCourse =
                 new FindCommand(new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"),
                         Arrays.asList("CS2101")));
-        assertParseSuccess(parser, "Alice Bob c/CS2101", expectedFindCommandWithNameAndCourse);
+        assertParseSuccess(parser, "find n/Alice Bob c/CS2101", expectedFindCommandWithNameAndCourse);
     }
 
 }

--- a/src/test/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicateTest.java
@@ -1,0 +1,110 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class NameOrCourseContainsKeywordsPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstNameKeywordList = Collections.singletonList("Alice");
+        List<String> secondNameKeywordList = Arrays.asList("Alice", "Bob");
+        List<String> firstCourseKeywordList = Collections.singletonList("CS2101");
+        List<String> secondCourseKeywordList = Arrays.asList("CS2101", "CS2103");
+
+        NameOrCourseContainsKeywordsPredicate firstPredicate =
+                new NameOrCourseContainsKeywordsPredicate(firstNameKeywordList, firstCourseKeywordList);
+        NameOrCourseContainsKeywordsPredicate secondPredicate =
+                new NameOrCourseContainsKeywordsPredicate(secondNameKeywordList, secondCourseKeywordList);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        NameOrCourseContainsKeywordsPredicate firstPredicateCopy =
+                new NameOrCourseContainsKeywordsPredicate(firstNameKeywordList, firstCourseKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different person -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameOrCourseContainsKeywords_returnsTrue() {
+        // One name keyword
+        NameOrCourseContainsKeywordsPredicate predicate =
+                new NameOrCourseContainsKeywordsPredicate(Collections.singletonList("Alice"), Collections.emptyList());
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2101").build()));
+
+        // One course keyword
+        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Collections.singletonList("CS2101"));
+        assertTrue(predicate.test(new PersonBuilder().withName("John Doe").withCourses("CS2101").build()));
+
+        // Multiple name keywords
+        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), Collections.emptyList());
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2103").build()));
+
+        // Multiple course keywords
+        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Arrays.asList("CS2101", "CS2103"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Charlie").withCourses("CS2103").build()));
+
+        // One matching keyword in name and one in course
+        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Charlie"), Arrays.asList("CS2101"));
+        assertTrue(predicate.test(new PersonBuilder().withName("Charlie Brown").withCourses("CS2101").build()));
+
+        // Mixed-case name keyword
+        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("aLIce"), Collections.emptyList());
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2103").build()));
+
+        // Mixed-case course keyword
+        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Arrays.asList("cs2101"));
+        assertTrue(predicate.test(new PersonBuilder().withName("John").withCourses("CS2101").build()));
+    }
+
+    @Test
+    public void test_nameOrCourseDoesNotContainKeywords_returnsFalse() {
+        // Zero keywords
+        NameOrCourseContainsKeywordsPredicate predicate =
+                new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withCourses("CS2101").build()));
+
+        // Non-matching name keyword
+        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Carol"), Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2101").build()));
+
+        // Non-matching course keyword
+        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Arrays.asList("CS9999"));
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withCourses("CS2101").build()));
+
+        // Keywords match phone, email, and address but not name or course
+        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"), Collections.emptyList());
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+                .withEmail("alice@email.com").withAddress("Main Street").withCourses("CS2101").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> nameKeywords = List.of("Alice", "Bob");
+        List<String> courseKeywords = List.of("CS2101");
+        NameOrCourseContainsKeywordsPredicate predicate = new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords);
+
+        String expected = NameOrCourseContainsKeywordsPredicate.class.getCanonicalName()
+                + "{nameKeywords=" + nameKeywords + ", courseKeywords=" + courseKeywords + "}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameOrCourseContainsKeywordsPredicateTest.java
@@ -52,7 +52,8 @@ public class NameOrCourseContainsKeywordsPredicateTest {
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2101").build()));
 
         // One course keyword
-        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Collections.singletonList("CS2101"));
+        predicate = new NameOrCourseContainsKeywordsPredicate(
+                Collections.emptyList(), Collections.singletonList("CS2101"));
         assertTrue(predicate.test(new PersonBuilder().withName("John Doe").withCourses("CS2101").build()));
 
         // Multiple name keywords
@@ -60,11 +61,13 @@ public class NameOrCourseContainsKeywordsPredicateTest {
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").withCourses("CS2103").build()));
 
         // Multiple course keywords
-        predicate = new NameOrCourseContainsKeywordsPredicate(Collections.emptyList(), Arrays.asList("CS2101", "CS2103"));
+        predicate = new NameOrCourseContainsKeywordsPredicate(
+                Collections.emptyList(), Arrays.asList("CS2101", "CS2103"));
         assertTrue(predicate.test(new PersonBuilder().withName("Charlie").withCourses("CS2103").build()));
 
         // One matching keyword in name and one in course
-        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("Alice", "Charlie"), Arrays.asList("CS2101"));
+        predicate = new NameOrCourseContainsKeywordsPredicate(
+                Arrays.asList("Alice", "Charlie"), Arrays.asList("CS2101"));
         assertTrue(predicate.test(new PersonBuilder().withName("Charlie Brown").withCourses("CS2101").build()));
 
         // Mixed-case name keyword
@@ -92,7 +95,8 @@ public class NameOrCourseContainsKeywordsPredicateTest {
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withCourses("CS2101").build()));
 
         // Keywords match phone, email, and address but not name or course
-        predicate = new NameOrCourseContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"), Collections.emptyList());
+        predicate = new NameOrCourseContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street"), Collections.emptyList());
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").withCourses("CS2101").build()));
     }
@@ -101,7 +105,8 @@ public class NameOrCourseContainsKeywordsPredicateTest {
     public void toStringMethod() {
         List<String> nameKeywords = List.of("Alice", "Bob");
         List<String> courseKeywords = List.of("CS2101");
-        NameOrCourseContainsKeywordsPredicate predicate = new NameOrCourseContainsKeywordsPredicate(nameKeywords, courseKeywords);
+        NameOrCourseContainsKeywordsPredicate predicate = new NameOrCourseContainsKeywordsPredicate(nameKeywords,
+                courseKeywords);
 
         String expected = NameOrCourseContainsKeywordsPredicate.class.getCanonicalName()
                 + "{nameKeywords=" + nameKeywords + ", courseKeywords=" + courseKeywords + "}";


### PR DESCRIPTION
Modify find command to filter contacts using the following parameters: 
- n/Name(s)
- c/Course(s)
- n/Name(s) c/Course(s)

**Scenario 1**
Command: find n/John
Output: Displays all contacts with names containing John

**Scenario 2**
Command: find n/John Doe
Output: Displays all contacts with names containing either 
- John
- Doe
- John Doe

(This is similar to the AB3 implementation.)

**Scenario 3**
Command: find c/CS2103T
Output: Displays all contacts with courses CS2103T

**Scenario 4**
Command: find c/CS2103T ST2334
Output: Displays all contacts with courses containing either
- CS2103T
- ST2334
- CS2103T ST2334

**Scenario 5**
Command: find n/Alice c/CS2103T
Output: Displays all contacts with names or courses containing
- Alice
- Alice CS2103T
- CS2103T

**Scenario 6**
Command: find n/Alice Doe c/CS2103T
Output: Displays all contacts with names or courses containing
- Alice
- Alice Doe
- Alice CS2103T
- Alice Doe CS2103T
- Doe
- Doe CS2103T
- CS2103T

**Scenario 7**
Command: find n/Alice c/CS2103T ST2334
Output: Displays all contacts with names or courses containing
- Alice
- Alice CS2103T
- Alice ST2334
- Alice CS2103T ST2334
- CS2103T
- CS2103T ST2334
- ST2334

**Scenario 8**
Command: find n/Alice Doe c/CS2101 ST2334
Output: Displays all contacts with names or courses containing
- Alice
- Alice Doe
- Alice CS2101
- Alice ST2334
- Alice Doe CS2101
- Alice Doe ST2334
- Alice Doe CS2101 ST2334
- Doe
- Doe CS2101
- Doe ST2334
- Doe CS2101 ST2334
- CS2101
- CS2101 ST2334
- ST2334